### PR TITLE
Override defaults, fixes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ module.exports = function(config) {
 
     frameworks: ['jasmine'],
 
-    reporters: ['jasmine-diff']
+    reporters: ['jasmine-diff'],
 
     colors: false
 
@@ -115,7 +115,7 @@ module.exports = function(config) {
 
     frameworks: ['jasmine'],
 
-    reporters: ['jasmine-diff']
+    reporters: ['jasmine-diff'],
 
     jasmineDiffReporter: {
       // Bg - background
@@ -139,6 +139,23 @@ Example: ![Example custom colors](http://i.imgur.com/eOTgERa.jpg "Example custom
 You can use any [colors](https://github.com/chalk/chalk#styles) that a supported by [`chalk`](https://github.com/chalk/chalk).
 
 Defaults for "expected" message is red background with white text and for "actual" - green background with white text. Default background and foreground is for a part of Jasmine object that was not changed, it allows to highlight the rest of the object and distinguish it from matcher text.
+
+To use default color use empty value:
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    jasmineDiffReporter: {
+      color: {
+        expectedBg: '',        // default 'bgRed'
+        expectedFg: 'green',   // default 'white'
+        actualBg: '',          // default 'bgGreen'
+        actualFg: 'red',       // default 'white',
+      }
+    }
+  });
+};
+```
 
 If you have `colors:false` in Karma config, none of the custom or default colors will be used, diffs will be inversed instead.
 

--- a/src/jasmine-diff.js
+++ b/src/jasmine-diff.js
@@ -62,8 +62,8 @@ function wrapActual(str, color) {
   color = color || {};
 
   var styles = [
-    color.actualBg || 'bgGreen',
-    color.actualFg || 'white'
+    color.hasOwnProperty('actualBg') ? color.actualBg : 'bgGreen',
+    color.hasOwnProperty('actualFg') ? color.actualFg : 'white'
   ];
 
   return wrapInColor(str, color.enabled, styles);
@@ -73,8 +73,8 @@ function wrapExpected(str, color) {
   color = color || {};
 
   var styles = [
-    color.expectedBg || 'bgRed',
-    color.expectedFg || 'white'
+    color.hasOwnProperty('expectedBg') ? color.expectedBg : 'bgRed',
+    color.hasOwnProperty('expectedFg') ? color.expectedFg : 'white'
   ];
 
   return wrapInColor(str, color.enabled, styles);


### PR DESCRIPTION
Now with config like this:
```js
    jasmineDiffReporter: {
      pretty: true,
      color: {
        expectedBg: '',
        expectedFg: 'red',
        actualBg: '',
        actualFg: 'green',
        defaultBg: '',
        defaultFg: 'grey'
      }
    },

```

I can achieve proper colors:

<img width="997" alt="20160117-200000" src="https://cloud.githubusercontent.com/assets/175264/12376679/f8a72a5a-bd54-11e5-826b-04dfd4c27daf.png">
