### PR TITLE
feat: Add a newLinesAroundMatchers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,27 @@ module.exports = function(config) {
 
 Example: ![Example pretty print](http://i.imgur.com/6TTlSmB.jpg "Example pretty print")
 
+##### New lines around matchers
+
+Option to wrap the matchers with new lines so it's easier to differentiate actual and expected blocks.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+
+    frameworks: ['jasmine'],
+
+    reporters: ['jasmine-diff'],
+
+    jasmineDiffReporter: {
+      newLinesAroundMatchers: true // default to false
+    }
+
+  });
+};
+```
+
 ### Dependencies
 
 - [diff](https://www.npmjs.com/package/diff) - Text differencing

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ function JasmineDiffReporter(baseReporterDecorator, config) {
   var options = {
     matchers: reporterOptions.matchers || {},
     color: reporterOptions.color || {},
-    pretty: reporterOptions.pretty || false
+    pretty: reporterOptions.pretty || false,
+    newLinesAroundMatchers: reporterOptions.newLinesAroundMatchers || false
   };
 
   options.color.enabled = !!config.colors;

--- a/src/jasmine-diff.js
+++ b/src/jasmine-diff.js
@@ -308,7 +308,11 @@ function createDiffMessage(message, options) {
 
     }
   });
-
+  
+  if (options.newLinesAroundMatchers) {
+    actualDiff += '\n';
+    expectedDiff = '\n' + expectedDiff;
+  }
 
   var replacePairs = [[expected, expectedDiff], [actual, actualDiff]];
   if (matcher.reverse) {


### PR DESCRIPTION
Option to wrap the matchers with new lines so it's easier to differentiate actual and expected blocks.