### PR TITLE
Fixed value.identity not being function. Jasmine v2+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea

--- a/demo/matcher-to-have-been-called-with.spec.js
+++ b/demo/matcher-to-have-been-called-with.spec.js
@@ -36,6 +36,28 @@ describe('Matcher', function () {
 
     });
 
+    it('Should correctly show spyOn value', function () {
+      function createUIEvent(reference) {
+        return {
+          tag: reference
+        };
+      }
+
+      var foo = {
+        bar: function () {},
+        foo: this
+      };
+
+      spyOn(foo, 'bar');
+
+      foo.bar({}, createUIEvent(foo));
+
+      expect(foo.bar).toHaveBeenCalledWith({}, {
+        bar: function () {},
+        foo: 'asd'
+      });
+    });
+
   });
 
 });

--- a/src/karma-jasmine/pp-patch.js
+++ b/src/karma-jasmine/pp-patch.js
@@ -79,7 +79,9 @@ function ppPatched(j$) {
       } else if (typeof value === 'string') {
         this.emitString(value);
       } else if (j$.isSpy(value)) {
-        this.emitScalar('spy on ' + value.and.identity());
+        var identity = value.and.identity;
+
+        this.emitScalar('spy on ' + (typeof identity === 'string' ? identity : value.and.identity() /* keep context of function same */));
       } else if (value instanceof RegExp) {
         this.emitScalar(value.toString());
       } else if (typeof value === 'function') {


### PR DESCRIPTION
Jasmine has changed type of identity from function to string in recent versions. 

This PR updates dependencies and fixes the error thrown when formatting spied object.

Jasmine change: https://github.com/jasmine/jasmine/commit/21655a82c9daf831ee0bf7dab27e758dd2fc0fb7#diff-8e852847e960ef28e9d01576424d9986

There is issue also about this:
https://github.com/mradionov/karma-jasmine-diff-reporter/issues/33

but it was closed without a fix. 
