### PR TITLE
Fix context in patched equals call

### DIFF
--- a/src/karma-jasmine/util-patch.js
+++ b/src/karma-jasmine/util-patch.js
@@ -9,7 +9,7 @@ window.jasmine.matchersUtil = matchersUtilPatched(window.jasmine);
 
 function matchersUtilPatched(j$) {
   var util = j$.matchersUtil;
-  var oldEquals = util.equals;
+  var oldEquals = util.equals.bind(util);
 
   // Below Jasmine 2.6 there is no NullDiffBuilder class
   if (typeof j$.NullDiffBuilder === 'undefined') {


### PR DESCRIPTION
Internally util.equals calls `this._eq`, but since `oldEquals` is called without context `this` ends up being window, on which _eq is undefined.